### PR TITLE
Limit Log Preview output to improve performance when viewing larger files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4270,6 +4270,11 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -14689,6 +14694,31 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-scripts": "^4.0.3",
     "react-syntax-highlighter": "^15.4.4",
     "react-transition-group": "^4.4.2",
+    "react-virtualized": "^9.22.3",
     "typescript": "^4.3.5"
   },
   "scripts": {

--- a/src/body/jobstatus.js
+++ b/src/body/jobstatus.js
@@ -756,6 +756,7 @@ class JobStatus extends Component{
             return style
           }}
 
+          // TODO: 2021/9/14 (Elvis) If using the virtualized renderer, work out how to scroll horizontally
           // renderer={this.myVirtualizedRenderer()}
         >
           {/* {text} */}

--- a/src/body/jobstatus.js
+++ b/src/body/jobstatus.js
@@ -42,6 +42,8 @@ import { Link as RouterLink } from 'react-router-dom';
 
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { AutoSizer, List as VirtualList } from 'react-virtualized';
+import { createElement } from 'react-syntax-highlighter';
 
 // Project imports
 import '../styles/jobstatus.css'
@@ -672,20 +674,92 @@ class JobStatus extends Component{
     return [null, null]
   }
 
+
+  // Adapted from react-syntax-highlighter-virtualized-renderer source: https://github.com/conorhastings/react-syntax-highlighter-virtualized-renderer/blob/master/src/index.jsx
+  logRowRenderer({ rows, stylesheet, useInlineStyles }) {
+    return ({ index, key, style }) => createElement({
+      node: rows[index],
+      stylesheet,
+      style,
+      useInlineStyles,
+      key,
+    });
+  }
+
+  // Adapted from react-syntax-highlighter-virtualized-renderer source: https://github.com/conorhastings/react-syntax-highlighter-virtualized-renderer/blob/master/src/index.jsx
+  myVirtualizedRenderer({ overscanRowCount = 10, rowHeight = 15, height = 700 } = {}) {
+    return ({ rows, stylesheet, useInlineStyles }) => (
+      <div style={{ height: '100%' }}>
+        <AutoSizer disableHeight>
+          {({ width }) => (
+            <VirtualList
+              // height={700}
+              height={height}
+              width={width}
+              rowHeight={rowHeight}
+              rowRenderer={this.logRowRenderer({ rows, stylesheet, useInlineStyles })}
+              rowCount={rows.length}
+              overscanRowCount={overscanRowCount}
+            />
+          )}
+        </AutoSizer>
+      </div>
+    )
+  }
+
+  // renderCodeBlock(log_key, language, filename){
   renderCodeBlock(text, language, filename){
     let code_block
     const code_block_style = {
-      maxHeight: 600
+      maxHeight: 700,
+      // display: 'flex'
+      // height: 600
+      height: "100%"
     }
 
     if(text){
+      const object_key = `${this.props.jobdate}/${this.props.jobid}/${filename}`
+      const num_lines_to_preview = 1000
+      const split_text = text.split('\n')
+      const num_lines = split_text.length
+      let preface_text = ""
+      let starting_line
+
+      if(num_lines < num_lines_to_preview){
+        starting_line = 1
+      }else{
+        const file_size = this.state.filesizes[this.props.jobtype][object_key]
+        preface_text = `Text too large (${num_lines} lines, ${this.formatBytes(file_size)}). Displaying last ${num_lines_to_preview} lines...\n\n`
+        // starting_line = num_lines - num_lines_to_preview + 1
+        starting_line = num_lines - num_lines_to_preview - 1  // extra -1 is to account for additional blank line after preface text
+      }
+
       code_block = 
         <SyntaxHighlighter
+          // className="syntaxhighlighter"
+          customStyle={code_block_style}
           language={language}
           style={atomOneDark}
           showLineNumbers={this.state.show_log_line_numbers}
+          showInlineLineNumbers={this.state.show_log_line_numbers}
+          startingLineNumber={starting_line}
+          lineNumberStyle={(lineNum) => {
+            let style = {
+              paddingLeft: '1em',
+              paddingRight: '1em',
+            }
+            if(starting_line !== 1 && lineNum <= (starting_line+1)){
+              // style.display = 'none'
+              style.visibility = 'hidden'
+            }
+
+            return style
+          }}
+
+          // renderer={this.myVirtualizedRenderer()}
         >
-          {text}
+          {/* {text} */}
+          {preface_text + split_text.slice(-num_lines_to_preview).join('\n')}
         </SyntaxHighlighter>
     }
     else{
@@ -727,13 +801,14 @@ class JobStatus extends Component{
 
       if(this.props.jobtype === JOBTYPES.PDB2PQR){
         logfile_view_pdb2pqr_only =
-          <Panel header={`Log (${log_filename})`} extra={createLogDownload( log_filename )}>
+          <Panel header={`Log (${log_filename})`} extra={createLogDownload( log_filename )} >
             {this.renderCodeBlock(this.state.logData.log, 'accesslog', `${this.props.jobid}.log`)}
           </Panel>
+        // logfile_view_pdb2pqr_only = this.renderCodeBlock(this.state.logData.log, 'accesslog', `${this.props.jobid}.log`)
       }
 
       return(
-        <div>
+        <div style={{height: '100%'}}>
           <Collapse bordered={false}>
             {logfile_view_pdb2pqr_only}
             <Panel header={`Stdout (${stdout_filename})`} extra={createLogDownload( stdout_filename )}>


### PR DESCRIPTION
Resolves #58 

### Changes
- Reduced max size of Log Preview panel to 700px
- If stdout/stderr/log file contains over 1000 lines, only the last 1000 lines are displayed.  This addresses performance issues encountered when attempting to preview larger log files.  User can download file if needing to view the full text.

### Sample
![image](https://user-images.githubusercontent.com/15897689/133312933-e6b62ead-288a-4807-b951-9c894090d403.png)

