### PR TITLE
Display job IDs with associated job date on status page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16547,9 +16547,9 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -156,14 +156,16 @@ class App extends Component {
       let job_id = query_args.get('jobid')
       let job_type = query_args.get('jobtype')
       let job_date = query_args.get('date')
+      const combinedJobIdDate = `${job_id}_${job_date.replaceAll('-', '')}` // removed dashes for aesthetic purposes
 
       document.title = `Job Status - ${job_id}`;
-      bcrumb = this.createServiceBreadcrumb(['Tools', 'Job Status', job_id])
+      bcrumb = this.createServiceBreadcrumb(['Tools', 'Job Status', combinedJobIdDate])
       content = 
         <JobStatus
           jobid={job_id}
           jobtype={job_type}
           jobdate={job_date}
+          combinedJobIdDate={combinedJobIdDate}
         />;
     }
 

--- a/src/body/jobstatus.js
+++ b/src/body/jobstatus.js
@@ -191,7 +191,7 @@ class JobStatus extends Component{
         duration: 0,
         // btn: acknowledgement_btn,
         description: 
-          `Files for the job ${this.props.jobid} will be retained for 14 DAYS following job creation.\
+          `Files for the job ${this.props.combinedJobIdDate} will be retained for 14 DAYS following job creation.\
             Please download the files you wish to keep in the meantime.`,
         // btn: (<Button type="primary" size="small" onClick={() => notification.close('data_retention_notice')}> Close </Button>)
       })
@@ -990,7 +990,7 @@ class JobStatus extends Component{
 
   renderJobStatsRow(){
     const jobtype = this.props.jobtype
-    const jobid = this.props.jobid
+    const combinedJobIdDate = this.props.combinedJobIdDate
     const elapsedTime = this.state.elapsedTime[jobtype] !== undefined ? this.state.elapsedTime[jobtype] : 'computing...'
 
     const continueButton = this.createNextProcessButton()
@@ -1002,27 +1002,31 @@ class JobStatus extends Component{
 
     return(
       <div>
-        <Row align="middle">
-          {/* Job ID section */}
-          <Col span={3} offset={1}>
-            <Text>Job ID:</Text><br/>
-            <Text strong style={{fontSize: 20}}>{jobid}</Text>
-          </Col>
+        <Row align="middle" justify="space-between">
+          <Col xs={11} xxl={8} offset={1}>
+            <Row justify="space-between">
+              {/* Job ID section */}
+              <Col>
+                <Text>Job ID:</Text><br/>
+                <Text strong style={{fontSize: 20}}>{combinedJobIdDate}</Text>
+              </Col>
 
-          {/* Job Type section */}
-          <Col span={3}>
-            <Text>Job Type:</Text><br/>
-            <Text strong style={{fontSize: 20}}>{jobtype.toUpperCase()}</Text>
-          </Col>
+              {/* Job Type section */}
+              <Col>
+                <Text>Job Type:</Text><br/>
+                <Text strong style={{fontSize: 20}}>{jobtype.toUpperCase()}</Text>
+              </Col>
 
-          {/* Elapsed time section */}
-          <Col span={3}>
-            <Text>Time Elapsed:</Text><br/>
-            <Text strong style={{fontSize: 20}}>{elapsedTime}</Text>
+              {/* Elapsed time section */}
+              <Col>
+                <Text>Time Elapsed:</Text><br/>
+                <Text strong style={{fontSize: 20}}>{elapsedTime}</Text>
+              </Col>
+            </Row>
           </Col>
 
           {/* Button for next process (e.g. APBS, 3Dmol) */}
-          <Col span={13}>
+          <Col span={3} pull={1}>
             <Row justify="end">
               <Col>
                 <Text>Next:</Text><br/>


### PR DESCRIPTION
Resolves #61 

### Changes
* Display job IDs with associated job date on Job Status page
* Spacing adjustments on job information row

### Sample
See the format underlined in red.  Dashes where removed from the date for reduced visual distraction and easier highlighting via a double-click:
![image](https://user-images.githubusercontent.com/15897689/134099129-2a973235-5316-4eaf-98db-a41457bb9882.png)

